### PR TITLE
feat: support immutable SQLite open for locked databases

### DIFF
--- a/lib/alite/core.rb
+++ b/lib/alite/core.rb
@@ -8,7 +8,7 @@ module Alite
     def initialize(config, verbose = false)
       @logger = get_logger(verbose)
       @config = config
-      @db = ::SQLite3::Database.new @config['database']
+      @db = open_database(@config)
       @table_name = @config['table_name']
       @where_match_columns = config['where_match_columns']
       @title_key = @config['title_key']
@@ -41,6 +41,19 @@ module Alite
       logger = Logger.new($stderr)
       logger.level = verbose ? Logger::DEBUG : Logger::INFO
       logger
+    end
+
+    # immutable: true の場合、SQLiteのURIファイル名 + immutable=1 で開く。
+    # ロックを一切取らないため、書き込み中のDB(例: 起動中ChromeのHistory)を
+    # コピーせず読み取り専用で直接参照できる。
+    def open_database(config)
+      path = config['database']
+      return ::SQLite3::Database.new(path) unless config['immutable']
+
+      ::SQLite3::Database.new(
+        "file:#{path}?immutable=1",
+        flags: ::SQLite3::Constants::Open::READONLY | ::SQLite3::Constants::Open::URI
+      )
     end
 
     def make_sql(query)

--- a/lib/alite/sql.rb
+++ b/lib/alite/sql.rb
@@ -10,7 +10,7 @@ module Alite
     def initialize(config, verbose = false)
       @logger = get_logger(verbose)
       @config = config
-      @db = ::SQLite3::Database.new @config['database']
+      @db = open_database(@config)
       @sql = @config['sql']
       @where_match_columns = config['where_match_columns']
 


### PR DESCRIPTION
## 概要

`immutable: true` を設定したプロファイルで、SQLite を URI ファイル名 `file:<path>?immutable=1`（`READONLY | URI` フラグ）で開けるようにしました。

`immutable=1` は SQLite にロックを一切取得させないため、**他プロセスが書き込み中の DB を、コピーせず読み取り専用で直接参照**できます。

## 動機

起動中の Chrome の `History` を読もうとすると、Chrome がロックを保持しているため `database is locked` で失敗します。これまでは事前に DB ファイルを `cp` してから開く回避策が必要でした。immutable オープンによりコピー前処理が不要になります。

## 変更点

- `Core` / `Sql` で重複していた DB オープン処理を `open_database` に共通化
- config に `immutable: true` がある場合のみ URI + immutable オープン
- 未指定時は従来どおり通常オープン（後方互換）

## 設定例

```yaml
chrome_history:
  database: '<%= ENV['HOME'] %>/Library/Application Support/Google/Chrome/Default/History'
  immutable: true
  table_name: urls
```

## テスト

- `rspec` 全 11 例パス
- 起動中 Chrome の実 History に対して、コピーなしで履歴取得を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)