### PR TITLE
test: expand test coverage across Core, Sql, CLI, and Util

### DIFF
--- a/spec/alite_spec.rb
+++ b/spec/alite_spec.rb
@@ -22,4 +22,23 @@ describe Alite do
     expect(result).to have_key(:items)
     expect(result[:items]).to be_an(Array)
   end
+
+  it 'suggest substitutes arg vars' do
+    result = Alite.suggest(
+      'myword2',
+      config: 'spec/data/alite.yml',
+      profile: 'with_arg_vars',
+      arg_vars: { 'id' => '123', 'name' => 'alice' }
+    )
+    expect(result[:items].first['arg']).to eq('https://example.com/123/alice')
+  end
+
+  it 'suggest routes sql profiles through the Sql core' do
+    result = Alite.suggest(
+      'myword2',
+      config: 'spec/data/alite.yml',
+      profile: 'sql_profile'
+    )
+    expect(result[:items].first['title']).to eq('myword2')
+  end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -34,4 +34,58 @@ describe Alite::CLI do
     expect(result).to have_key('items')
     expect(result['items']).to be_an(Array)
   end
+
+  it 'filters results by the given query' do
+    output = capture_stdout do
+      Alite::CLI.start([
+                         'script_filter',
+                         '--query', 'myword2',
+                         '--config', 'spec/data/alite.yml',
+                         '--profile', 'default'
+                       ])
+    end
+    result = JSON.parse(output)
+    expect(result['items'].length).to eq(1)
+    expect(result['items'].first['title']).to eq('myword2')
+  end
+
+  it 'substitutes arg vars passed via --arg_vars' do
+    output = capture_stdout do
+      Alite::CLI.start([
+                         'script_filter',
+                         '--query', 'myword2',
+                         '--arg_vars', 'id:123', 'name:alice',
+                         '--config', 'spec/data/alite.yml',
+                         '--profile', 'with_arg_vars'
+                       ])
+    end
+    result = JSON.parse(output)
+    expect(result['items'].first['arg']).to eq('https://example.com/123/alice')
+  end
+
+  it 'works with a custom sql profile' do
+    output = capture_stdout do
+      Alite::CLI.start([
+                         'script_filter',
+                         '--query', 'myword2',
+                         '--config', 'spec/data/alite.yml',
+                         '--profile', 'sql_profile'
+                       ])
+    end
+    result = JSON.parse(output)
+    expect(result['items'].first['title']).to eq('myword2')
+  end
+
+  it 'maps -s to the script_filter command' do
+    output = capture_stdout do
+      Alite::CLI.start([
+                         '-s',
+                         '--query', 'myword2',
+                         '--config', 'spec/data/alite.yml',
+                         '--profile', 'default'
+                       ])
+    end
+    result = JSON.parse(output)
+    expect(result['items'].first['title']).to eq('myword2')
+  end
 end

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -40,4 +40,108 @@ describe Alite::Core do
     result = @core.make_script_filter('nonexistent_keyword_xyz')
     expect(result[:items]).to be_empty
   end
+
+  it 'deduplicates rows via select distinct' do
+    # The fixture has two "myword" rows; distinct collapses them to one.
+    result = @core.make_script_filter('myword')
+    titles = result[:items].map { |item| item['title'] }
+    expect(titles.count('myword')).to eq(1)
+  end
+
+  it 'returns all rows when the query is empty' do
+    result = @core.make_script_filter('')
+    expect(result[:items].length).to eq(2)
+  end
+
+  it 'sets autocomplete to the title by default' do
+    result = @core.make_script_filter('myword2')
+    item = result[:items].first
+    expect(item['autocomplete']).to eq(item['title'])
+  end
+
+  it 'marks items as valid' do
+    result = @core.make_script_filter('myword2')
+    expect(result[:items].first['valid']).to eq(true)
+  end
+
+  describe 'multi-word query' do
+    it 'requires every word to match (AND semantics)' do
+      result = @core.make_script_filter('myword foo')
+      expect(result[:items]).to be_empty
+    end
+  end
+
+  describe 'where_base option' do
+    it 'restricts results with the configured base condition' do
+      config = Util.get_profile('spec/data/alite.yml', 'with_where_base')
+      result = Core.new(config).make_script_filter('')
+      expect(result[:items].length).to eq(1)
+      expect(result[:items].first['title']).to eq('myword2')
+    end
+  end
+
+  describe 'initial_limit option' do
+    it 'limits the number of returned items' do
+      config = Util.get_profile('spec/data/alite.yml', 'with_limit')
+      result = Core.new(config).make_script_filter('')
+      expect(result[:items].length).to eq(1)
+    end
+  end
+
+  describe 'no order option' do
+    it 'still returns results when order is not configured' do
+      config = Util.get_profile('spec/data/alite.yml', 'no_order')
+      result = Core.new(config).make_script_filter('myword2')
+      expect(result[:items].first['title']).to eq('myword2')
+    end
+  end
+
+  describe 'uid option' do
+    it 'adds a uid equal to the arg when enabled' do
+      config = Util.get_profile('spec/data/alite.yml', 'with_uid')
+      result = Core.new(config).make_script_filter('myword2')
+      item = result[:items].first
+      expect(item).to have_key('uid')
+      expect(item['uid']).to eq(item['arg'])
+    end
+
+    it 'does not add a uid when disabled' do
+      result = @core.make_script_filter('myword2')
+      expect(result[:items].first).not_to have_key('uid')
+    end
+  end
+
+  describe 'immutable option' do
+    it 'opens the database read-only and still returns results' do
+      config = Util.get_profile('spec/data/alite.yml', 'immutable_profile')
+      result = Core.new(config).make_script_filter('myword2')
+      expect(result[:items].first['title']).to eq('myword2')
+    end
+  end
+
+  describe 'arg_vars substitution' do
+    it 'substitutes ${var} placeholders in arg with provided values' do
+      config = Util.get_profile('spec/data/alite.yml', 'with_arg_vars')
+      result = Core.new(config).make_script_filter('myword2', { 'id' => '123', 'name' => 'alice' })
+      expect(result[:items].first['arg']).to eq('https://example.com/123/alice')
+    end
+
+    it 'accepts symbol keys for arg vars' do
+      config = Util.get_profile('spec/data/alite.yml', 'with_arg_vars')
+      result = Core.new(config).make_script_filter('myword2', { id: '123', name: 'alice' })
+      expect(result[:items].first['arg']).to eq('https://example.com/123/alice')
+    end
+
+    it 'leaves unknown placeholders untouched' do
+      config = Util.get_profile('spec/data/alite.yml', 'with_arg_vars')
+      result = Core.new(config).make_script_filter('myword2', { 'id' => '123' })
+      expect(result[:items].first['arg']).to eq('https://example.com/123/${name}')
+    end
+
+    it 'returns the raw arg when no arg vars are given' do
+      config = Util.get_profile('spec/data/alite.yml', 'with_arg_vars')
+      result = Core.new(config).make_script_filter('myword2')
+      expect(result[:items].first['arg']).to eq('https://example.com/${id}/${name}')
+    end
+  end
 end

--- a/spec/data/alite.yml
+++ b/spec/data/alite.yml
@@ -9,3 +9,92 @@ default:
     - keyword
   order: created_at
   initial_limit: 30
+
+no_order:
+  adapter: sqlite3
+  database: 'spec/data/alite.db'
+  table_name: keywords
+  title_key: keyword
+  subtitle_key: keyword
+  arg_key: keyword
+  where_match_columns:
+    - keyword
+
+with_limit:
+  adapter: sqlite3
+  database: 'spec/data/alite.db'
+  table_name: keywords
+  title_key: keyword
+  subtitle_key: keyword
+  arg_key: keyword
+  where_match_columns:
+    - keyword
+  initial_limit: 1
+
+with_where_base:
+  adapter: sqlite3
+  database: 'spec/data/alite.db'
+  table_name: keywords
+  title_key: keyword
+  subtitle_key: keyword
+  arg_key: keyword
+  where_match_columns:
+    - keyword
+  where_base: "keyword = 'myword2'"
+
+with_uid:
+  adapter: sqlite3
+  database: 'spec/data/alite.db'
+  table_name: keywords
+  title_key: keyword
+  subtitle_key: keyword
+  arg_key: keyword
+  where_match_columns:
+    - keyword
+  uid: true
+
+with_arg_vars:
+  adapter: sqlite3
+  database: 'spec/data/alite.db'
+  table_name: keywords
+  title_key: keyword
+  subtitle_key: keyword
+  arg_key: "'https://example.com/${id}/${name}'"
+  where_match_columns:
+    - keyword
+
+erb_profile:
+  adapter: sqlite3
+  database: "<%= 'spec/data/alite.db' %>"
+  table_name: keywords
+  title_key: keyword
+  subtitle_key: keyword
+  arg_key: keyword
+  where_match_columns:
+    - keyword
+
+immutable_profile:
+  adapter: sqlite3
+  database: 'spec/data/alite.db'
+  table_name: keywords
+  title_key: keyword
+  subtitle_key: keyword
+  arg_key: keyword
+  where_match_columns:
+    - keyword
+  immutable: true
+
+sql_profile:
+  adapter: sqlite3
+  database: 'spec/data/alite.db'
+  sql: "select distinct keyword as title, keyword as subtitle, keyword as arg from keywords where 1 = 1 order by created_at desc limit 30"
+  where_match_columns:
+    - keyword
+
+sql_uid_profile:
+  adapter: sqlite3
+  database: 'spec/data/alite.db'
+  sql: "select distinct keyword as title, keyword as subtitle, keyword as arg from keywords where 1 = 1 limit 30"
+  where_match_columns:
+    - keyword
+  uid: true

--- a/spec/sql_spec.rb
+++ b/spec/sql_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'alite'
+
+describe Alite::Sql do
+  let(:core) do
+    config = Util.get_profile('spec/data/alite.yml', 'sql_profile')
+    Sql.new(config)
+  end
+
+  it 'builds without error from a sql profile' do
+    expect(core).not_to be_nil
+  end
+
+  it 'returns script filter results using the custom sql' do
+    result = core.make_script_filter('myword')
+    expect(result).to have_key(:items)
+    expect(result[:items]).to be_an(Array)
+    expect(result[:items].length).to be > 0
+  end
+
+  it 'injects the match query into the where clause' do
+    result = core.make_script_filter('myword2')
+    expect(result[:items].length).to eq(1)
+    expect(result[:items].first['title']).to eq('myword2')
+  end
+
+  it 'returns all rows when the query is empty' do
+    result = core.make_script_filter('')
+    expect(result[:items].length).to eq(2)
+  end
+
+  it 'returns empty results for a non-matching query' do
+    result = core.make_script_filter('nonexistent_xyz')
+    expect(result[:items]).to be_empty
+  end
+
+  it 'adds a uid to items when the uid option is enabled' do
+    config = Util.get_profile('spec/data/alite.yml', 'sql_uid_profile')
+    result = Sql.new(config).make_script_filter('myword2')
+    expect(result[:items].first).to have_key('uid')
+  end
+end

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'alite'
+
+describe Alite::Util do
+  describe '.get_profile' do
+    it 'returns nil when the config file does not exist' do
+      expect(Util.get_profile('spec/data/does_not_exist.yml', 'default')).to be_nil
+    end
+
+    it 'returns the config hash for an existing profile' do
+      config = Util.get_profile('spec/data/alite.yml', 'default')
+      expect(config).to be_a(Hash)
+      expect(config['database']).to eq('spec/data/alite.db')
+      expect(config['table_name']).to eq('keywords')
+    end
+
+    it 'returns nil for a non-existent profile' do
+      expect(Util.get_profile('spec/data/alite.yml', 'no_such_profile')).to be_nil
+    end
+
+    it 'evaluates ERB expressions in the config' do
+      config = Util.get_profile('spec/data/alite.yml', 'erb_profile')
+      expect(config['database']).to eq('spec/data/alite.db')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
テストを充実させました。これまで未カバーだった挙動に対するテストを追加し、スイートを 11 → 42 examples に拡張しています。

## 追加したカバレッジ
- **`Alite::Sql`** — これまで完全に未テストだったクラス。カスタム `sql` プロファイル、match クエリの WHERE 句への注入、`uid` オプション。
- **`Alite::Util.get_profile`** — ファイル不在時の `nil`、存在しないプロファイル、ERB 評価。
- **`arg_vars` 置換** — `${var}` プレースホルダの置換（文字列キー / シンボルキー / 未知のプレースホルダはそのまま残す / 未指定時は生の値）。
- **`Alite::Core` の各オプション** — `uid` / `where_base` / `initial_limit` / `order` 未設定 / 複数語クエリの AND セマンティクス / `select distinct` の重複排除 / `valid`・`autocomplete` のデフォルト値。
- **`immutable`** — 読み取り専用（URI + `immutable=1`）でのオープン。
- **`Alite::CLI`** — `--arg_vars` (`-a`)、`sql` プロファイル、`-s` から `script_filter` へのマッピング、クエリによる絞り込み。

これらを支えるためのプロファイルを `spec/data/alite.yml` に追加しています（既存の `default` プロファイルは変更なし）。

## Test
- `bundle exec rspec` → 42 examples, 0 failures
- `bundle exec rubocop spec/` → no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)